### PR TITLE
Dev seperate ci cd pipeline #29

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,0 +1,24 @@
+name: dev-testing-the-waters
+on:
+  push:
+    branches:
+    - "dev-**"
+jobs:
+  Build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone down
+        uses: actions/checkout@v3
+      - name: Install go
+        uses: actions/actions/setup-go@v4
+      - name: Build backend
+        run: cd backend && go build
+      - name: Build frontend
+        run: cd frontend && go build
+      - name: Test frontend
+        run: cd frontend && go test
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: code
+          path: .

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Clone down
         uses: actions/checkout@v3
       - name: Install go
-        uses: actions/actions/setup-go@v4
+        uses: actions/setup-go@v4
       - name: Build backend
         run: cd backend && go build
       - name: Build frontend

--- a/kubernetes/backend-deployment.yml
+++ b/kubernetes/backend-deployment.yml
@@ -18,7 +18,13 @@ spec:
           resources: {}
           env:
             - name: REDIS_DNS
-              value: redis-server
+              valueFrom:
+                configMapKeyRef:
+                  name: redis-config
+                  key: REDIS_DNS
             - name: REDIS_PORT
-              value: "6379"
+              valueFrom:
+                configMapKeyRef:
+                  name: redis-config
+                  key: REDIS_PORT
             

--- a/kubernetes/redis-config.yml
+++ b/kubernetes/redis-config.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: redis-config
+data:
+  REDIS_DNS: redis-server
+  REDIS_PORT: "6379"


### PR DESCRIPTION
Adds a new workflow that runs on push on development branches.
Branches should now have the naming prefix: "dev-<name>".

Closes #29 